### PR TITLE
Make envs match the bash script

### DIFF
--- a/sync-server/example.env
+++ b/sync-server/example.env
@@ -1,8 +1,8 @@
 # Rename to .env and update the following with your own values:
 
-SYNC_HOSTNAMENAME= # example: your-time-thief-sync.me
+SYNC_HOSTNAME= # example: your-time-thief-sync.me
 COUCHDB_ADMIN_PASSWORD=
-SYNC_USER_NAME=
+SYNC_USER=
 SYNC_PASSWORD=
 
 # Optional overrides


### PR DESCRIPTION
The bash script expects `SYNC_HOSTNAME` and `SYNC_USER` as values, this updates the `example.env` to match.